### PR TITLE
fix currency units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
+target/
+result/
+
 scratch
-result


### PR DESCRIPTION
Use actual currency for network rather than bcrt for everything.

The .gitignore update was so I could run `tree --gitignore`, for some reason that command follows a stricter format than git itself.